### PR TITLE
New Highlight engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ This will make all "unknown" words as "known", except the words you excluded in 
 - <kbd>↓</kbd> scroll down dict section
 - <kbd>↑</kbd> scroll up dict section
 - <kbd>ESC</kbd> close dict panel / close zen mode
-- <kbd>a</kbd> mark as known
-- <kbd>s</kbd> save context
 
 ## Similar projects
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This will make all "unknown" words as "known", except the words you excluded in 
 - <kbd>↓</kbd> scroll down dict section
 - <kbd>↑</kbd> scroll up dict section
 - <kbd>ESC</kbd> close dict panel / close zen mode
+- <kbd>a</kbd> mark as known
+- <kbd>s</kbd> save context
 
 ## Similar projects
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Word Hunter",
   "description": "Discover new words you don't know on any web page",
-  "version": "1.0.28",
+  "version": "1.1.0",
   "manifest_version": 3,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA37Tu6LgsThnqIusXCvgDP+kzjHmJgwehDp01nEvTCH3N19Qpe3+q6o20yjMfyT1681f3mzugV4scpjSsYH7ixO8wZHDNBwJlPPLV8jjpwRd/rBiXLYw7sSSHsX1dN7mQuKdua7WrsN+CUc7s8acq0F9lAXGtsk/BA3tNSidB5kVmog1iLf3m6wbbYK9wKmlgIjw8OkAxOs4YnZ/Z5Dfj4lPZ0aYxUmQkXSZgc3Jj0IUiQBfY3+RsJw0u7M2njPlU6AQ8pPET3BHY86ee0xSksINMrVYYMjAmHv+05RzIF+rANlHGqHYoPaD3z/rxkeki4uXXkVEi4Yv+AhdKxGUwYwIDAQAB",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-hunter",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "author": "sapjax",
   "description": "",
   "type": "module",

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -90,7 +90,6 @@ export const invalidTags = [
   'WH-ROOT'
 ]
 
-export const wordReplaceRegex = /(\b)([a-z]+)(\b)/gi
 export const wordRegex = /^[a-z]+$/i
 export const cnRegex = /[\u4E00-\u9FA5]+/
 

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -31,10 +31,6 @@ export type WordContext = {
 export type ContextMap = Record<string, WordContext[]>
 
 export const classes = {
-  mark: '__mark',
-  mark_parent: '__mark_parent',
-  known: '__word_known',
-  unknown: '__word_unknown',
   card: 'word_card',
   zen_mode: '__zen_mode',
   excluded: '__excluded'
@@ -94,13 +90,9 @@ export const invalidTags = [
   'WH-ROOT'
 ]
 
-export const invalidSelectors = ['.monaco-editor', '.CodeMirror-code', '#video-title']
-
-export const wordReplaceRegex = /(\b|\s)([a-z]+)(\s|,|\.|\b)/gi
+export const wordReplaceRegex = /(\b)([a-z]+)(\b)/gi
 export const wordRegex = /^[a-z]+$/i
 export const cnRegex = /[\u4E00-\u9FA5]+/
-
-export const keepTextNodeHosts = ['reader.ttsu.app']
 
 /**
  * group storage.sync items by word prefix, to avoid hitting the 512 items and 8kb limit per item.

--- a/src/content/card.tsx
+++ b/src/content/card.tsx
@@ -180,6 +180,12 @@ export const WhCard = customElement('wh-card', () => {
         if (e.key === 'Escape') {
           hidePopupDelay(0)
         }
+        if (e.key === 'a') {
+          onKnown(e)
+        }
+        if (e.key === 's') {
+          onAddContext(e)
+        }
         e.preventDefault()
       }
     }

--- a/src/content/highlight.ts
+++ b/src/content/highlight.ts
@@ -230,6 +230,10 @@ function highlightTextNode(node: CharacterData, dict: WordInfoMap, wordsKnown: W
 
         const trans = settings().showCnTrans && fullDict[originFormWord]?.t
         if (trans) {
+          // avoid duplicated
+          if (range.endContainer.nextSibling?.nodeName === 'W-MARK-T') {
+            continue
+          }
           // insert trans tag after range
           const newRange = range.cloneRange()
           newRange.collapse(false)

--- a/src/content/index.css
+++ b/src/content/index.css
@@ -1,33 +1,5 @@
 @import url('../assets/font.css');
 
-/* some site set style to role=button globally, we need to prevent it for mark */
-w-mark[role='button'] {
-  all: unset;
-  color: inherit;
-}
-
-.__mark {
-  display: inline;
-}
-
-.__word_unknown,
-.__zen_mode .__word_unknown {
-  pointer-events: auto;
-  -webkit-text-fill-color: currentColor !important;
-  &[have_context] {
-    &::after {
-      font-size: 50%;
-      vertical-align: super;
-      content: '(' attr(have_context) ')';
-    }
-  }
-  &[have_context='1'] {
-    &::after {
-      display: none;
-    }
-  }
-}
-
 w-mark-t {
   position: relative;
   display: inline-block;
@@ -70,10 +42,6 @@ w-mark-t {
   }
 }
 
-.pdfViewer .__word_unknown {
-  color: transparent;
-}
-
 body:has(.__zen_mode) {
   overflow: hidden;
 }
@@ -90,13 +58,10 @@ body:has(.__zen_mode) {
   font-family: BlinkMacSystemFont, sans-serif;
 
   pre {
+    padding: 0;
+    margin: 0;
     background-color: unset !important;
     border: none !important;
-  }
-
-  w-mark-parent {
-    display: inline-flex;
-    align-items: center;
   }
 
   .zen_close_btn {
@@ -117,6 +82,7 @@ body:has(.__zen_mode) {
     margin-bottom: 40px;
     button {
       padding: 5px 10px;
+      font-size: 14px;
       img {
         vertical-align: middle;
         margin-right: 10px;
@@ -129,18 +95,17 @@ body:has(.__zen_mode) {
     column-gap: 7rem;
     column-rule: 4px dotted turquoise;
     word-break: break-all;
-  }
-
-  w-mark {
-    display: inline-block;
-    break-inside: avoid;
-    white-space: nowrap;
-    font-size: 12px;
-    line-height: 1.5;
-    padding: 0 2px;
-    margin: 5px 5px !important;
-    &:nth-child(20n) {
-      margin-bottom: 50px;
+    span {
+      display: inline-block;
+      break-inside: avoid;
+      white-space: nowrap;
+      font-size: 12px;
+      line-height: 1.5;
+      padding: 0 2px;
+      margin: 5px 5px !important;
+      &:nth-child(20n) {
+        margin-bottom: 50px;
+      }
     }
   }
 

--- a/src/content/index.css
+++ b/src/content/index.css
@@ -88,6 +88,17 @@ body:has(.__zen_mode) {
         margin-right: 10px;
       }
     }
+    label {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      cursor: pointer;
+      color: #666;
+      font-size: 14px;
+      input {
+        cursor: pointer;
+      }
+    }
   }
 
   .zen_words {

--- a/src/lib/markStyle.ts
+++ b/src/lib/markStyle.ts
@@ -1,56 +1,39 @@
 import { settings, MarkStyles } from './settings'
 import { invertHexColor } from './utils'
-import { classes } from '../constant'
 
 export function genMarkStyle() {
-  const unknownSelector = `.${classes.mark}.${classes.unknown}`
-  const contextSelector = `.${classes.mark}.${classes.unknown}[have_context]`
+  const unknownSelector = `::highlight(wh-unknown)`
+  const contextSelector = `::highlight(wh-context)`
   const markStyle = settings().markStyle ?? MarkStyles[0]
+  const textColor0 = invertHexColor(settings()['colors'][0])
+  const textColor1 = invertHexColor(settings()['colors'][1])
+  const bgColor0 = settings()['colors'][0]
+  const bgColor1 = settings()['colors'][1]
 
-  let style = `
-    :root {
-      --wh-mark-text-color-0: ${invertHexColor(settings()['colors'][0])};
-      --wh-mark-text-color-1: ${invertHexColor(settings()['colors'][1])};
-      --wh-mark-color-0: ${settings()['colors'][0]};
-      --wh-mark-color-1: ${settings()['colors'][1]};
-    }
+  let style = ` `
 
-  `
   switch (markStyle) {
     case 'text':
       style += `
         ${unknownSelector} {
-          color: var(--wh-mark-color-0);
+          color: ${bgColor0};
         }
         ${contextSelector} {
-          color: var(--wh-mark-color-1);
+          color: ${bgColor1};
         }
       `
       break
     case 'background':
       style += `
         ${unknownSelector} {
-          color: var(--wh-mark-text-color-0);
-          background-color: var(--wh-mark-color-0);
+          color: ${textColor0};
+          background-color: ${bgColor0};
           border-radius: 0.3em;
-          padding-inline: 0.1em;
-          margin-inline: -0.1em;
 
         }
         ${contextSelector} {
-          color: var(--wh-mark-text-color-1);
-          background-color: var(--wh-mark-color-1);
-        }
-      `
-      break
-    case 'outline':
-      style += `
-        ${unknownSelector} {
-          outline: inset var(--wh-mark-color-0) !important;
-          border-radius: 0.3em;
-        }
-        ${contextSelector} {
-          outline: inset var(--wh-mark-color-1) !important;
+          color: ${textColor1};
+          background-color: ${bgColor1};
         }
       `
       break
@@ -59,22 +42,22 @@ export function genMarkStyle() {
         ${unknownSelector} {
           text-decoration-line: underline;
           text-decoration-style: dashed;
-          text-decoration-color: var(--wh-mark-color-0);
+          text-decoration-color: ${bgColor0};
         }
         ${contextSelector} {
-          text-decoration-color: var(--wh-mark-color-1);
+          text-decoration-color: ${bgColor1};
         }
       `
       break
     case 'dotted':
       style += `
-         ${unknownSelector} {
+        ${unknownSelector} {
           text-decoration-line: underline;
           text-decoration-style: dotted;
-          text-decoration-color: var(--wh-mark-color-0);
+          text-decoration-color: ${bgColor0};
         }
         ${contextSelector} {
-          text-decoration-color: var(--wh-mark-color-1);
+          text-decoration-color: ${bgColor1};
         }
       `
       break
@@ -83,10 +66,10 @@ export function genMarkStyle() {
         ${unknownSelector} {
           text-decoration-line: underline;
           text-decoration-style: solid;
-          text-decoration-color: var(--wh-mark-color-0);
+          text-decoration-color: ${bgColor0};
         }
         ${contextSelector} {
-          text-decoration-color: var(--wh-mark-color-1);
+          text-decoration-color: ${bgColor1};
         }
       `
       break
@@ -95,10 +78,10 @@ export function genMarkStyle() {
         ${unknownSelector} {
           text-decoration-line: underline;
           text-decoration-style: double;
-          text-decoration-color: var(--wh-mark-color-0);
+          text-decoration-color: ${bgColor0};
         }
         ${contextSelector} {
-          text-decoration-color: var(--wh-mark-color-1);
+          text-decoration-color: ${bgColor1};
         }
       `
       break
@@ -107,159 +90,24 @@ export function genMarkStyle() {
         ${unknownSelector} {
           text-decoration-line: underline;
           text-decoration-style: wavy;
-          text-decoration-color: var(--wh-mark-color-0);
-          ${contextSelector} {
-             text-decoration-color: var(--wh-mark-color-1);
-          }
-        }
-      `
-      break
-    case 'emphasis-dot':
-      style += `
-        ${unknownSelector} {
-         text-emphasis: dot;
-         text-emphasis-position: under right;
-         text-emphasis-color: var(--wh-mark-color-0);
+          text-decoration-color: ${bgColor0};
         }
         ${contextSelector} {
-          text-emphasis-color: var(--wh-mark-color-1);
+          text-decoration-color: ${bgColor1};
         }
       `
       break
-    case 'emphasis-circle':
+    default:
       style += `
         ${unknownSelector} {
-         text-emphasis: circle;
-         text-emphasis-position: under right;
-         text-emphasis-color: var(--wh-mark-color-0);
-          ${contextSelector} {
-            text-emphasis-color: var(--wh-mark-color-1);
-          }
-        }
-      `
-      break
-    case 'emphasis-open-circle':
-      style += `
-        ${unknownSelector} {
-         text-emphasis: open circle;
-         text-emphasis-position: under right;
-         text-emphasis-color: var(--wh-mark-color-0);
+          color: ${textColor0};
+          background-color: ${bgColor0};
+          border-radius: 0.3em;
+
         }
         ${contextSelector} {
-          text-emphasis-color: var(--wh-mark-color-1);
-        }
-      `
-      break
-    case 'emphasis-triangle':
-      style += `
-        ${unknownSelector} {
-         text-emphasis: triangle;
-         text-emphasis-position: under right;
-         text-emphasis-color: var(--wh-mark-color-0);
-        }
-        ${contextSelector} {
-          text-emphasis-color: var(--wh-mark-color-1);
-        }
-      `
-      break
-    case 'shape':
-      style += `
-        ${unknownSelector} {
-          position:relative;
-          &::before {
-            content: " ";
-            display: block;
-            height: 1em;
-            width: 100%;
-            margin-left: -3px;
-            margin-right: -3px;
-            position: absolute;
-            background: var(--wh-mark-color-0);
-            transform: rotate(2deg);
-            top: -1px;
-            left: -1px;
-            border-radius: 20% 25% 20% 24%;
-            padding: 0 3px 3px 3px;
-            opacity: 0.3;
-          }
-        }
-        ${contextSelector} {
-          &::before {
-            background: var(--wh-mark-color-1);
-          }
-        }
-      `
-      break
-    case 'slanting':
-      style += `
-        ${unknownSelector} {
-          position:relative;
-          &::before {
-            position: absolute;
-            z-index: -1;
-            content: "";
-            width: calc(100% + 4px);
-            height: 60%;
-            left: -2px;
-            bottom: 0;
-            transform: rotate(-2deg);
-            background: linear-gradient(135deg, var(--wh-mark-color-0) 0%, rgba(0,0,0,0) 100%);
-          }
-        }
-        ${contextSelector} {
-          &::before {
-            background: linear-gradient(135deg, var(--wh-mark-color-1) 0%, rgba(0,0,0,0) 100%);
-          }
-        }
-      `
-      break
-    case 'pen':
-      style += `
-        ${unknownSelector} {
-          position:relative;
-          font-family: Libre Franklin;
-          &::before{
-            content:"";
-            z-index:-1;
-            left:-0.5em;
-            top:-0.1em;
-            border-width:2px;
-            border-style:solid;
-            border-color:var(--wh-mark-color-0);
-            position:absolute;
-            border-right-color:transparent;
-            width:100%;
-            height:1em;
-            transform:rotate(2deg);
-            opacity:0.7;
-            border-radius:50%;
-            padding:0.1em 0.25em;
-          }
-          &:after{
-            content:"";
-            left:-0.5em;
-            top:0.1em;
-            padding:0.1em 0.25em;
-            border-width:2px;
-            border-style:solid;
-            border-color:var(--wh-mark-color-0);
-            border-left-color:transparent;
-            border-top-color:transparent;
-            position:absolute;
-            width:100%;
-            height:1em;
-            transform:rotate(-1deg);
-            opacity:0.7;
-            border-radius:50%;
-          }
-        }
-        ${contextSelector} {
-          &::before {
-            border-color: var(--wh-mark-color-1);
-          }
-          &::after {
-            border-color: var(--wh-mark-color-1);
-          }
+          color: ${textColor1};
+          background-color: ${bgColor1};
         }
       `
       break

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -13,27 +13,11 @@ const DEFAULT_DICTS = {
 export type DictName = keyof typeof DEFAULT_DICTS
 export type MouseKey = 'NONE' | 'ctrlKey' | 'altKey' | 'shiftKey' | 'metaKey'
 
-export const MarkStyles = [
-  'background',
-  'text',
-  'outline',
-  'underline',
-  'double-underline',
-  'wavy',
-  'dotted',
-  'dashed',
-  'emphasis-dot',
-  'emphasis-circle',
-  'emphasis-open-circle',
-  'emphasis-triangle',
-  'shape',
-  'slanting',
-  'pen'
-] as const
+export const MarkStyles = ['background', 'text', 'underline', 'double-underline', 'wavy', 'dotted', 'dashed'] as const
 
 export const DEFAULT_SETTINGS = {
   colors: ['#9FB0EF', '#C175D8'],
-  markStyle: 'background' as typeof MarkStyles[number],
+  markStyle: 'background' as (typeof MarkStyles)[number],
   blacklist: [] as string[],
   dictTabs: DEFAULT_DICTS,
   dictOrder: Object.keys(DEFAULT_DICTS) as DictName[],

--- a/src/options/colors.tsx
+++ b/src/options/colors.tsx
@@ -14,6 +14,15 @@ export const ColorsSetting = () => {
     setSetting('markStyle', target.value as (typeof MarkStyles)[number])
   }
 
+  // for the breaking change of removing depleted markStyles
+  const resolvedMarkStyle = () => {
+    const s = settings().markStyle
+    if (!MarkStyles.includes(s)) {
+      return MarkStyles[0]
+    }
+    return s
+  }
+
   return (
     <>
       <section class="section">
@@ -47,7 +56,7 @@ export const ColorsSetting = () => {
           <span class="z-0">Mark</span> style:
         </h2>
         <div class="flex flex-col items-end gap-4 mt-4">
-          <select class="select select-bordered max-w-xs" value={settings().markStyle} onChange={onMarkStyleChanged}>
+          <select class="select select-bordered max-w-xs" value={resolvedMarkStyle()} onChange={onMarkStyleChanged}>
             <For each={MarkStyles}>
               {item => (
                 <option id={item} value={item}>

--- a/src/options/colors.tsx
+++ b/src/options/colors.tsx
@@ -1,4 +1,3 @@
-import { classes } from '../constant'
 import { settings, setSetting, MarkStyles, genMarkStyle } from '../lib'
 import { For } from 'solid-js'
 
@@ -45,10 +44,7 @@ export const ColorsSetting = () => {
 
       <section class="section">
         <h2 class="h2">
-          <span class="z-0" classList={{ [classes.unknown]: true, [classes.mark]: true }}>
-            Mark
-          </span>{' '}
-          style:
+          <span class="z-0">Mark</span> style:
         </h2>
         <div class="flex flex-col items-end gap-4 mt-4">
           <select class="select select-bordered max-w-xs" value={settings().markStyle} onChange={onMarkStyleChanged}>

--- a/src/popup/statistics.tsx
+++ b/src/popup/statistics.tsx
@@ -6,7 +6,7 @@ export const Statistics = () => {
   const [counts, setCounts] = createSignal([0, 0, 1]) // unknown,  have context, total
   const getStatistics = async () => {
     const res = await executeScript(() => {
-      return window.__getPageStatistics()
+      return window.__getPageStatistics?.()
     })
     setCounts([...res[0].result])
   }


### PR DESCRIPTION
**Highlight text without modifying the DOM.**

This PR is intended to solve a big common problem:
modifying DOM makes virtual DOM diff disordered, often resulting in duplicated content *(see https://github.com/sapjax/word-hunter/issues/12)* or not updating.
like on the YouTube page, the video title mismatches the video thumb image after the router changes.

By using `Highlight` API to highlight ranges, we avoid modifying DOM now and get better highlight performance.

**There are also some Cons:**
- CSS highlight only supports [several style properties](https://developer.mozilla.org/en-US/docs/Web/CSS/::highlight#allowable_properties), we have to remove the unsupported mark style options, even for the `background` style, we can't set it border radius now.
- `::highlight` seems to consume GPU resources more than normal, and the animation performance is worse than the last version.
- the Chinese transition using `Range.insertNode` to insert the translation content after word range, which has poor performance, needs to be optimized later.

