### PR TITLE
fix: replace audio source's protocol

### DIFF
--- a/src/content/adapters/google/index.ts
+++ b/src/content/adapters/google/index.ts
@@ -95,7 +95,7 @@ export class GoogleDict implements Adapter {
         (el as HTMLSourceElement).src ??
         'https://www.google.com/speech-api/v1/synthesize?enc=mpeg&lang=zh-cn&speed=0.4&client=lr-language-tts&use_google_only_voices=1&text=' +
           encodeURIComponent(word)
-      el.closest('.brWULd')?.setAttribute('data-src-mp3', src)
+      el.closest('.brWULd')?.setAttribute('data-src-mp3', src.replace(/^file/, 'https'))
       el.parentElement?.remove()
     })
 


### PR DESCRIPTION
The Google Dictionary's audio address lacks a protocol. When browsing a local file, this issue can cause the entire browser to crash.